### PR TITLE
Adapt dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
+    groups:
+      dependencies:
+        patterns:
+          - "*" # Update all packages together


### PR DESCRIPTION
Use grouped dependencies, and only check for updates weekly.